### PR TITLE
Persist site changes to ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.6 (2020-10-14)
+* Update corresponding ingress when site URL is changed
+* Delete corresponding ingress when a site is deleted
+
 ## 0.7.5 (2020-09-29)
 * Update openstad logo
 

--- a/routes/site/site.js
+++ b/routes/site/site.js
@@ -287,6 +287,10 @@ module.exports = function(app){
 
       if (req.site.config && req.site.config.cms && req.site.config.cms.dbName) {
         deleteActions.push(deleteMongoDb(req.site.config.cms.dbName));
+        
+        if (process.env.KUBERNETES_NAMESPACE) {
+          deleteActions.push(k8Ingress.delete(req.site.config.cms.dbName));
+        }
       }
 
       Promise.all(deleteActions)

--- a/routes/site/site.js
+++ b/routes/site/site.js
@@ -248,34 +248,21 @@ module.exports = function(app){
 
         promises.push(userClientApi.update(req.userApiClient.clientId, clientData));
       }
+      
+      if (process.env.KUBERNETES_NAMESPACE) {
+        promises.push(k8Ingress.edit(siteData.config.cms.dbName, domain));
+      }
 
       /**
        * Import all promises
        */
       Promise.all(promises)
         .then(async function (response) {
-          
-          if (process.env.KUBERNETES_NAMESPACE) {
-            console.log('patch ingress:');
-            
-            try {
-              await k8Ingress.edit(siteData.config.cms.dbName, domain);
-              
-              
-              req.flash('success', { msg: 'Url aangepast!'});
-              res.redirect(req.header('Referer')  || appUrl);
-            } catch(error) {
-              console.error(error);
-              req.flash('error', { msg: 'Er gaat iets mis!'});
-              res.redirect(req.header('Referer')  || appUrl);
-            }
-          } else {
-            req.flash('success', { msg: 'Url aangepast!'});
-            res.redirect(req.header('Referer')  || appUrl);
-          }
-          
+          req.flash('success', { msg: 'Url aangepast!'});
+          res.redirect(req.header('Referer')  || appUrl);
         })
         .catch(function (err) {
+          console.error(err);
           req.flash('error', { msg: 'Er gaat iets mis!'});
           res.redirect(req.header('Referer')  || appUrl);
         });

--- a/services/k8/ingress.js
+++ b/services/k8/ingress.js
@@ -1,6 +1,47 @@
 const k8s = require('@kubernetes/client-node');
 
 /**
+ * Return the body to create / replace a namespaced ingress through the API
+ *
+ * @param databaseName
+ * @param domain
+ * @returns {{metadata: {name: *, annotations: {"cert-manager.io/cluster-issuer": string, "kubernetes.io/ingress.class": string}}, apiVersions: string, kind: string, spec: {rules: [{host: *, http: {paths: [{path: string, backend: {servicePort: number, serviceName: string}}]}}], tls: [{secretName: *, hosts: [*]}]}}}
+ */
+const getIngressBody = (databaseName, domain) => {
+
+  return {
+    apiVersions: 'networking.k8s.io/v1beta1',
+    kind: 'Ingress',
+    metadata: {
+      name: databaseName,
+      annotations: {
+        'cert-manager.io/cluster-issuer': 'openstad-letsencrypt-prod', // Todo: make this configurable
+        'kubernetes.io/ingress.class': 'nginx'
+      }
+    },
+    spec: {
+      rules: [{
+        host: domain,
+        http: {
+          paths: [{
+            backend: {
+              serviceName: 'openstad-frontend', // Todo: make this configurable
+              servicePort: 4444 // Todo: make this configurable
+            },
+            path: '/'
+          }]
+        }
+      }],
+      tls: [{
+        secretName: databaseName,
+        hosts: [domain]
+      }]
+    }
+  }
+
+};
+
+/**
  *
  * @param newSite
  * @returns {Promise<{response: http.IncomingMessage; body: NetworkingV1beta1Ingress}>}
@@ -11,73 +52,20 @@ exports.add = async (newSite) => {
 
   const k8sApi = kc.makeApiClient(k8s.NetworkingV1beta1Api);
 
-  return k8sApi.createNamespacedIngress(process.env.KUBERNETES_NAMESPACE, {
-    apiVersions: 'networking.k8s.io/v1beta1',
-    kind: 'Ingress',
-    metadata: {
-      name: newSite.getCmsDatabaseName(),
-      annotations: {
-        'cert-manager.io/cluster-issuer': 'openstad-letsencrypt-prod', // Todo: make this configurable
-        'kubernetes.io/ingress.class': 'nginx'
-      }
-    },
-    spec: {
-      rules: [{
-        host: newSite.getDomain(),
-        http: {
-          paths: [{
-            backend: {
-              serviceName: 'openstad-frontend', // Todo: make this configurable
-              servicePort: 4444 // Todo: make this configurable
-            },
-            path: '/'
-          }]
-        }
-      }],
-      tls: [{
-        secretName: newSite.getCmsDatabaseName(),
-        hosts: [newSite.getDomain()]
-      }]
-    }
-  });
+  return k8sApi.createNamespacedIngress(process.env.KUBERNETES_NAMESPACE, getIngressBody(newSite.getCmsDatabaseName(), newSite.getDomain()));
 };
 
-exports.edit = async (cmsDatabaseName, newDomain) => {
-  
-  console.log ('edit ingress', cmsDatabaseName, newDomain);
-  
+/**
+ *
+ * @param databaseName
+ * @param newDomain
+ * @returns {Promise<*>}
+ */
+exports.edit = async (databaseName, newDomain) => {
   const kc = new k8s.KubeConfig();
   kc.loadFromCluster();
 
   const k8sApi = kc.makeApiClient(k8s.NetworkingV1beta1Api);
 
-  return k8sApi.replaceNamespacedIngress(cmsDatabaseName, process.env.KUBERNETES_NAMESPACE, {
-    apiVersions: 'networking.k8s.io/v1beta1',
-    kind: 'Ingress',
-    metadata: {
-      name: cmsDatabaseName,
-      annotations: {
-        'cert-manager.io/cluster-issuer': 'openstad-letsencrypt-prod', // Todo: make this configurable
-        'kubernetes.io/ingress.class': 'nginx'
-      }
-    },
-    spec: {
-      rules: [{
-        host: newDomain,
-        http: {
-          paths: [{
-            backend: {
-              serviceName: 'openstad-frontend', // Todo: make this configurable
-              servicePort: 4444 // Todo: make this configurable
-            },
-            path: '/'
-          }]
-        }
-      }],
-      tls: [{
-        secretName: cmsDatabaseName,
-        hosts: [newDomain]
-      }]
-    }
-  });
+  return k8sApi.replaceNamespacedIngress(databaseName, process.env.KUBERNETES_NAMESPACE, getIngressBody(databaseName, newDomain));
 };

--- a/services/k8/ingress.js
+++ b/services/k8/ingress.js
@@ -51,7 +51,7 @@ exports.edit = async (cmsDatabaseName, newDomain) => {
 
   const k8sApi = kc.makeApiClient(k8s.NetworkingV1beta1Api);
 
-  return k8sApi.patchNamespacedIngress(cmsDatabaseName, process.env.KUBERNETES_NAMESPACE, {
+  return k8sApi.replaceNamespacedIngress(cmsDatabaseName, process.env.KUBERNETES_NAMESPACE, {
     apiVersions: 'networking.k8s.io/v1beta1',
     kind: 'Ingress',
     metadata: {

--- a/services/k8/ingress.js
+++ b/services/k8/ingress.js
@@ -75,4 +75,4 @@ exports.edit = async (databaseName, newDomain) => {
  */
 exports.delete = async (databaseName) => {
   return getK8sApi().deleteNamespacedIngress(databaseName, process.env.KUBERNETES_NAMESPACE);
-}
+};


### PR DESCRIPTION
This expands and refactors the ingress service with an `edit` and `delete` method. These methods are called respectively when a URL for a site has changed and when a site is to be deleted. This change ensures that the Ingress is up-to-date with our site URLs and that a new certificate can be acquired.

This fixes #1.